### PR TITLE
docs: replace stale Dependabot workflow reference with Renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ GitHub Actions workflows are configured for automated quality assurance:
 
 - **ci.yml**: Unit tests, build verification, and type checking across Node.js 22.x and 24.x
 - **playwright.yml**: Multi-browser end-to-end test execution
-- **auto-merge-dependabot.yml**: Automated dependency update integration
+
+Dependency updates are automated by [Renovate](renovate.json5).
 
 ## Build Configuration
 


### PR DESCRIPTION
## Summary

Remove a stale reference to a removed `auto-merge-dependabot.yml` workflow from the README CI section, and document that dependency updates are automated by Renovate (`renovate.json5`).

Follow-up to the Dependabot-to-Renovate migration: the workflow file does not exist on `main`, so the README listing was inaccurate.